### PR TITLE
Updated admin menu access to use roles and not levels

### DIFF
--- a/openam-rest.php
+++ b/openam-rest.php
@@ -302,7 +302,7 @@ function openam_login_url($login_url, $redirect = null) {
  * Function used to add the options menu in the wordpress console
  */
 function openam_rest_plugin_menu() {
-  add_options_page('OpenAM-REST Plugin Options', 'OpenAM-REST Plugin', 8, 'openam', 'openam_rest_plugin_options');
+  add_options_page('OpenAM-REST Plugin Options', 'OpenAM-REST Plugin', 'manage_options', 'openam', 'openam_rest_plugin_options');
 }
 
 /*


### PR DESCRIPTION
User "levels" are deprecated, updated to use "roles" in deciding who can see the plugin options in the admin interface. Ref. http://codex.wordpress.org/User_Levels

This removes the debug message seen in the admin interface that warps the "Settings" submenu.
