### PR TITLE
Fix incompatibilities with AM 5.x

### DIFF
--- a/openam-rest.php
+++ b/openam-rest.php
@@ -3,7 +3,7 @@
 Plugin Name: OpenAM Authentication
 Plugin URI: https://forgerock.org
 Description: This plugin is used to authenticate users using OpenAM. The plugin uses REST calls to the OpenAM. The required REST APIs are: /json/authenticate; /json/users/ and /json/sessions. Therefore you need OpenAM 11.0 and above. This plugin is not supported officially by ForgeRock.
-Version: 1.4
+Version: 1.5
 Author: Victor info@forgerock.com, openam@forgerock.org (subscribe to mailing list firt)
 Author URI: http://www.forgerock.org
 Text Domain: openam-auth
@@ -22,12 +22,12 @@ Text Domain: openam-auth
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2014-2016 ForgeRock AS.
+ * Copyright 2014-2017 ForgeRock AS.
  */
 
 defined( 'ABSPATH' ) or die();
 
-define( 'OPENAM_PLUGIN_VERSION', '1.4' );
+define( 'OPENAM_PLUGIN_VERSION', '1.5' );
 
 include 'openam-settings.php';
 include 'plugin-update.php';
@@ -120,7 +120,7 @@ function openam_sso() {
 	// Let's see if the user is already logged in the IDP.
         // Notice that the OPENAM_COOKIE_NAME Will be accessible for this plugin only if the OpenAM and Wordpress are in the SAME DOMAIN!
 	if ( isset( $_COOKIE[ OPENAM_COOKIE_NAME ] ) ) {
-		$tokenId = $_COOKIE[ OPENAM_COOKIE_NAME ];
+		$tokenId = trim($_COOKIE[ OPENAM_COOKIE_NAME ],  '"');
 		if ( ! empty( $tokenId ) && ! is_user_logged_in() ) {
 			openam_debug( 'openam_auth: TOKENID:' . $tokenId );
 			if ( $am_response = openam_sessionsdata( $tokenId ) ) {
@@ -192,7 +192,7 @@ function openam_sessionsdata( $tokenId ) {
 			'redirection' => 5,
 			'httpversion' => '1.0',
 			'blocking'    => true,
-			'headers'     => array('Content-Type' => 'application/json'),
+			'headers'     => array('Content-Type' => 'application/json', 'Accept-API-Version' => 'resource=1.0, protocol=1.0'),
 			'body'        => array(),
 			'sslverify'   => OPENAM_SSLVERIFY,
 			'cookies'     => array(),
@@ -232,7 +232,7 @@ function openam_sessionsdata( $tokenId ) {
 }
 
 
-/* Loads a user if found, if not it creates it in the local database using the 
+/* Loads a user if found, if not it creates it in the local database using the
  * attributes pulled from OpenaM
  */
 function loadUser( $login, $mail ) {
@@ -546,7 +546,7 @@ function createOpenAMLoginURL() {
 
 function openam_login_url( $login_url, $redirect = null ) {
 	openam_debug('openam_login_url: The current login URL is: ' . $login_url);
-	
+
 	if ( OPENAM_DO_REDIRECT ) {
 		$new_url = createOpenAMLoginURL();
 		if ( ! stripos( $new_url, '?' ) ) {
@@ -561,8 +561,8 @@ function openam_login_url( $login_url, $redirect = null ) {
 	}
 }
 
-/* Writes to the debug file if debugging has been enabled 
- * 
+/* Writes to the debug file if debugging has been enabled
+ *
  */
 function openam_debug( $message ) {
 	if ( OPENAM_DEBUG_ENABLED ) {
@@ -591,5 +591,3 @@ function openam_get_attribute_value( $attributes, $attributeId ) {
 function openam_i18n() {
 	load_plugin_textdomain( 'openam-auth', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 }
-
-

--- a/openam-rest.php
+++ b/openam-rest.php
@@ -22,7 +22,7 @@ Text Domain: openam-auth
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2014-2017 ForgeRock AS.
+ * Copyright 2014-2016 ForgeRock AS.
  */
 
 defined( 'ABSPATH' ) or die();
@@ -120,7 +120,7 @@ function openam_sso() {
 	// Let's see if the user is already logged in the IDP.
         // Notice that the OPENAM_COOKIE_NAME Will be accessible for this plugin only if the OpenAM and Wordpress are in the SAME DOMAIN!
 	if ( isset( $_COOKIE[ OPENAM_COOKIE_NAME ] ) ) {
-		$tokenId = trim($_COOKIE[ OPENAM_COOKIE_NAME ],  '"');
+		$tokenId = trim($_COOKIE[ OPENAM_COOKIE_NAME ], '"');
 		if ( ! empty( $tokenId ) && ! is_user_logged_in() ) {
 			openam_debug( 'openam_auth: TOKENID:' . $tokenId );
 			if ( $am_response = openam_sessionsdata( $tokenId ) ) {
@@ -232,7 +232,7 @@ function openam_sessionsdata( $tokenId ) {
 }
 
 
-/* Loads a user if found, if not it creates it in the local database using the
+/* Loads a user if found, if not it creates it in the local database using the 
  * attributes pulled from OpenaM
  */
 function loadUser( $login, $mail ) {
@@ -546,7 +546,7 @@ function createOpenAMLoginURL() {
 
 function openam_login_url( $login_url, $redirect = null ) {
 	openam_debug('openam_login_url: The current login URL is: ' . $login_url);
-
+	
 	if ( OPENAM_DO_REDIRECT ) {
 		$new_url = createOpenAMLoginURL();
 		if ( ! stripos( $new_url, '?' ) ) {
@@ -561,8 +561,8 @@ function openam_login_url( $login_url, $redirect = null ) {
 	}
 }
 
-/* Writes to the debug file if debugging has been enabled
- *
+/* Writes to the debug file if debugging has been enabled 
+ * 
  */
 function openam_debug( $message ) {
 	if ( OPENAM_DEBUG_ENABLED ) {
@@ -591,3 +591,5 @@ function openam_get_attribute_value( $attributes, $attributeId ) {
 function openam_i18n() {
 	load_plugin_textdomain( 'openam-auth', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 }
+
+


### PR DESCRIPTION
Hi,

I really made only 2 real code changes and bumped the version to 1.5. Not sure why the compare view shows 500+ changes when I only changed 3 lines of code and one comment. Here are the critical things I did:

**function openam_sso()**
Trimmed cookie value on line 123 to make function _openam_sessionsdata_ work properly. Older versions of OpenAM must have not set the cookie with double quotes:

_Old:_
```
$tokenId = $_COOKIE[ OPENAM_COOKIE_NAME ];
```
_New:_
```
$tokenId = trim($_COOKIE[ OPENAM_COOKIE_NAME ],  '"');
```

**function openam_sessionsdata()**
Forced API version by setting header  "Accept-API-Version: resource=2.0, protocol=1.0" to make the REST call work against AM 5.x. A better option might be to add an AM version selector (or use the API version selector that already exists) and call the new and improved API instead of calling an old version on a new AM instance. On line 195:

_Old:_
```
'headers'     => array('Content-Type' => 'application/json'),
```
_New:_
```
'headers'     => array('Content-Type' => 'application/json', 'Accept-API-Version' => 'resource=1.0, protocol=1.0'),
```

Cheers.
Volker