### PR TITLE
Fix for AM 6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 Wordpress plugin to authenticate using OpenAM
 <b>OpenAM Authentication</b>
 <table border="0">
-<tr><td>Contributors:</td><td>forgerock1, forgerock, marius-g, qcastel, bjornjohansen, degerstrom, vscheuber</td></tr>
+<tr><td>Contributors:</td><td>forgerock1, forgerock, marius-g, qcastel, bjornjohansen, degerstrom, vscheuber, zoltantarcsay</td></tr>
 <tr><td>Link:</td><td> http://www.forgerock.org/</td></tr>
-<tr><td>Tags:</td><td> OpenAM, Authentication, REST, OpenAM 11.0.1, OpenAM 12.0, Wordpress 3.9 & 4.4.2</td></tr>
+<tr><td>Tags:</td><td> OpenAM, Authentication, REST, OpenAM 11.0.1, OpenAM 12.0, Wordpress 3.9 & 4.4.2, ForgeRock, Access Management</td></tr>
 <tr><td>Requires at least:</td><td> 3.9</td></tr>
 <tr><td>Tested up to:</td><td>4.7.5</td></tr>
 <tr><td>Stable tag:</td><td>1.5</td></tr>

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 === OpenAM Authentication ===
-Contributors: forgerock1, forgerock, marius-g, qcastel, bjornjohansen, degerstrom, vscheuber
+Contributors: forgerock1, forgerock, marius-g, qcastel, bjornjohansen, degerstrom, vscheuber, zoltantarcsay
 Link: http://www.forgerock.org/
 Tags: OpenAM, Authentication, REST, OpenAM 11.0.1, OpenAM 12.0, OpenAM 13.0, Wordpress 3.9 & 4.4.2
 Requires at least: 3.9

--- a/openam-rest.php
+++ b/openam-rest.php
@@ -408,7 +408,7 @@ function getAttributesFromModernOpenAM( $tokenId, $username, $attributes ) {
 	$attributes_url = createAttributesURL();
 	openam_debug( 'getAttributesFromModernOpenAM: ATTRIBUTE URL: ' . $attributes_url );
 	$headers = array(
-		OPENAM_COOKIE_NAME => $tokenId,
+		'Cookie'           => OPENAM_COOKIE_NAME."=".$tokenId,
 		'Content-Type'     => 'application/json',
 	);
 	$url = $attributes_url . $username . '?_fields=' . $attributes;


### PR DESCRIPTION
getAttributesFromModernOpenAM makes a call to AM to get profile attributes; in AM 6.5 this needs a cookie header rather than a header with the cookie name (this change is backwards compatible with older versions of AM/OpenAM)